### PR TITLE
Changes to entry roster page.

### DIFF
--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -199,7 +199,7 @@ class EntryController extends Controller
             }
 
         }
-
+//dd($transactions);
         $playersActive = $entry->current_players()->leftJoin('teams', 'players.team_id', '=', 'teams.id')->leftJoin('games',function($join) {
             $join->on(\DB::raw('( teams.id = games.home_team_id OR teams.id = games.away_team_id) and 1 '),'=',\DB::raw('1'));
         })->whereRaw('(`games`.`winning_team_id` = `teams`.`id` OR `games`.`winning_team_id` = 0 OR `games`.`id` IS NULL)')->groupBy('players.id')->pluck('players.id');
@@ -225,6 +225,7 @@ class EntryController extends Controller
         $transaction=Transaction::findOrFail($request->input('transaction_id'));
         EntryPlayer::where('entry_id',$transaction->entry_id)->where('player_id',$transaction->dropped_player_id)->update(['removed_at' => NULL]);
         EntryPlayer::where('entry_id',$transaction->entry_id)->where('player_id',$transaction->added_player_id)->delete();
+        $transaction->delete();
         return redirect()->back()->with('success', 'Player change cancelled.');
     }
 

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -186,7 +186,7 @@ class EntryController extends Controller
             ->leftJoin('games',function($join) {
             $join->on(\DB::raw('( teams.id = games.home_team_id OR teams.id = games.away_team_id) and games.kickoff>ep2.created_at '),'=',\DB::raw('1'));
         })->where('entry_player.entry_id',$entry->id)->whereNotNull('entry_player.removed_at')->where('kickoff','>',now())->groupBy('ep2.player_id')->get();
-
+//
         $playersActive = $entry->current_players()->leftJoin('teams', 'players.team_id', '=', 'teams.id')->leftJoin('games',function($join) {
             $join->on(\DB::raw('( teams.id = games.home_team_id OR teams.id = games.away_team_id) and 1 '),'=',\DB::raw('1'));
         })->whereRaw('(`games`.`winning_team_id` = `teams`.`id` OR `games`.`winning_team_id` = 0 OR `games`.`id` IS NULL)')->groupBy('players.id')->pluck('players.id');

--- a/app/Http/Livewire/PlayerSelector.php
+++ b/app/Http/Livewire/PlayerSelector.php
@@ -93,7 +93,7 @@ class PlayerSelector extends Component
             return;
         }
 
-        if ($this->entry->changes_remaining <= 0) {
+        if ($this->entry->getChangesRemaining() <= 0) {
             $this->dispatch('showDialog', [
                 'type' => 'error',
                 'message' => 'No changes remaining'
@@ -163,14 +163,14 @@ class PlayerSelector extends Component
 //                    'roster_position' => $this->rosterPosition
 //                ]);
 //
-//                // Create single transaction record
-//                Transaction::create([
-//                    'entry_id' => $this->entry->id,
-//                    'dropped_player_id' => $this->currentPlayerId,
-//                    'added_player_id' => $this->selectedPlayerId,
-//                    'roster_position' => $this->rosterPosition,
-//                    'processed_at' => $now
-//                ]);
+                // Create single transaction record
+                Transaction::create([
+                    'entry_id' => $this->entry->id,
+                    'dropped_player_id' => $this->currentPlayerId,
+                    'added_player_id' => $this->selectedPlayerId,
+                    'roster_position' => $this->rosterPosition,
+                    'processed_at' => $now
+                ]);
 
                 //if any games started decrease changes remaining.   If no games started unlimited changes allowed.
                 if($gamesStarted = Game::where('kickoff', '<=', Carbon::now())->first()) {

--- a/app/Http/Livewire/PlayerSelector.php
+++ b/app/Http/Livewire/PlayerSelector.php
@@ -35,8 +35,14 @@ class PlayerSelector extends Component
         ->where('entry_id', $this->entry->id)
         ->pluck('player_id');
 
+
+    $playersOut = Player::query()->leftJoin('teams', 'players.team_id', '=', 'teams.id')->leftJoin('games',function($join) {
+        $join->on(\DB::raw('( teams.id = games.home_team_id OR teams.id = games.away_team_id) and 1 '),'=',\DB::raw('1'));
+    })->whereRaw('(`games`.`winning_team_id` != `teams`.`id` AND `games`.`winning_team_id` != 0 AND `games`.`id` IS NOT NULL)')->groupBy('players.id')->pluck('players.id');
+
+
     // Create array of all excluded player IDs including current player
-    $excludedPlayerIds = $usedPlayerIds->merge($droppedPlayerIds)
+    $excludedPlayerIds = $usedPlayerIds->merge($droppedPlayerIds)->merge($playersOut)
         ->push($this->currentPlayerId)  // Add current player to excluded list
         ->unique()
         ->values();

--- a/app/Http/Livewire/PositionSwapper.php
+++ b/app/Http/Livewire/PositionSwapper.php
@@ -1,0 +1,53 @@
+<?php
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+use App\Models\Entry;
+use App\Models\Player;
+
+class PositionSwapper extends Component
+{
+    public $entry;
+    public $currentPlayerId;
+    public $rosterPosition;
+    public $swapWithId;
+
+    public function mount(Entry $entry, $currentPlayerId, $rosterPosition)
+    {
+        $this->entry = $entry;
+        $this->currentPlayerId = $currentPlayerId;
+        $this->rosterPosition = $rosterPosition;
+    }
+
+    public function swapPosition()
+    {
+        if (!$this->swapWithId) {
+            $this->emit('showDialog', ['type' => 'error', 'message' => 'Please select a player to swap with']);
+            return;
+        }
+
+        try {
+            $response = $this->entry->swapWithFlex($this->currentPlayerId, $this->swapWithId);
+            $this->emit('showDialog', ['type' => 'success', 'message' => 'Positions successfully swapped']);
+            $this->emit('playerUpdated');
+        } catch (\Exception $e) {
+            $this->emit('showDialog', ['type' => 'error', 'message' => $e->getMessage()]);
+        }
+    }
+
+    public function render()
+    {
+        $eligiblePlayers = $this->entry->current_players()
+            ->whereNull('entry_player.removed_at')
+            ->where(function ($query) {
+                $query->where('roster_position', 'FLEX')
+                    ->orWhereIn('position', ['RB', 'WR', 'TE']);
+            })
+            ->where('players.id', '!=', $this->currentPlayerId)
+            ->get();
+
+        return view('livewire.position-swapper', [
+            'eligiblePlayers' => $eligiblePlayers
+        ]);
+    }
+}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -69,9 +69,18 @@ class Entry extends Model
     }
     public function current_players(): BelongsToMany
     {
-        //->whereNull('entry_player.removed_at')
         return $this->belongsToMany(Player::class, 'entry_player')
             ->using(EntryPlayer::class)
+            ->whereNull('entry_player.removed_at')
+            ->withPivot('roster_position')
+            ->withPivot('removed_at')
+            ->withTimestamps();
+    }
+    public function changed_players(): BelongsToMany
+    {
+        return $this->belongsToMany(Player::class, 'entry_player')
+            ->using(EntryPlayer::class)
+            ->whereNotNull('entry_player.removed_at')
             ->withPivot('roster_position')
             ->withPivot('removed_at')
             ->withTimestamps();
@@ -80,7 +89,10 @@ class Entry extends Model
     {
         return $this->hasMany(EntryPlayer::class);
     }
-
+    public function getChangesRemaining(): float
+    {
+        return (10-$this->playerList()->count());
+    }
     public function players(): BelongsToMany
     {
         return $this->belongsToMany(Player::class, 'entry_player')

--- a/app/Models/EntryPlayer.php
+++ b/app/Models/EntryPlayer.php
@@ -18,7 +18,8 @@ class EntryPlayer extends Pivot
         'divisional_points',
         'conference_points',
         'superbowl_points',
-        'total_points'
+        'total_points',
+        'removed_at'
     ];
 
     public static function boot()

--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -30,6 +30,40 @@ class Player extends Model
         return $this->belongsTo(Team::class);
     }
 
+    public function games()
+    {
+        $gamesHome = $this->home_games;
+        $gamesAway = $this->away_games;
+        // Merge collections and return single collection.
+        return $gamesHome->merge($gamesAway);
+    }
+
+
+
+    public function home_games()
+    {
+        return $this->hasManyThrough(
+            Game::class,
+            Team::class,
+            'id', // Foreign key on the environments table...
+            'home_team_id', // Foreign key on the deployments table...
+            'team_id', // Local key on the projects table...
+            'id' // Local key on the environments table...
+        );
+    }
+
+    public function away_games()
+    {
+        return $this->hasManyThrough(
+            Game::class,
+            Team::class,
+            'id', // Foreign key on the environments table...
+            'away_team_id', // Foreign key on the deployments table...
+            'team_id', // Local key on the projects table...
+            'id' // Local key on the environments table...
+        );
+    }
+
     public function stats(): HasMany
     {
         return $this->hasMany(PlayerStats::class);

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Transaction extends Model
 {
+    use SoftDeletes;
+
     protected $fillable = [
         'entry_id',
         'dropped_player_id',
@@ -16,9 +19,8 @@ class Transaction extends Model
         'notes'
     ];
 
-    protected $dates = [
-        'processed_at'
-    ];
+    protected $dates = ['deleted_at','processed_at'];
+
 
     // Update the $with array to use consistent naming
     protected $with = ['entry', 'droppedPlayer', 'addedPlayer'];

--- a/database/migrations/2024_12_18_131045_add_soft_delete_transactions.php
+++ b/database/migrations/2024_12_18_131045_add_soft_delete_transactions.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        //
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/views/entries/roster.blade.php
+++ b/resources/views/entries/roster.blade.php
@@ -150,7 +150,17 @@
                                         :rosterPosition="$player->pivot->roster_position"
                                         :key="'player-'.$player->id" />
                                 </div>
+
                                 @endif
+                                    @if(is_null($player->pivot->removed_at) && !in_array($player->id, $lockedPlayers->pluck('id')->toArray()))
+                                        <div>
+                                            <livewire:position-swapper
+                                                :entry="$entry"
+                                                :currentPlayerId="$player->id"
+                                                :rosterPosition="$player->pivot->roster_position"
+                                                :key="'swap-'.$player->id" />
+                                        </div>
+                                    @endif
                             @elseif(is_null($player->pivot->removed_at))
                                 <span class="text-red-500">Locked</span>
                             @else

--- a/resources/views/entries/roster.blade.php
+++ b/resources/views/entries/roster.blade.php
@@ -1,69 +1,4 @@
 <x-app-layout>
-<!-- Dialog Component -->
-<div x-data="{
-    isOpen: false,
-    type: '',
-    message: '',
-    show(data) {
-        this.type = data.type;
-        this.message = data.message;
-        this.isOpen = true;
-    },
-    hide() {
-        this.isOpen = false;
-    }
-}"
-@showdialog.window="show($event.detail)"
-class="relative z-50">
-
-    <!-- Background overlay -->
-    <div x-show="isOpen"
-         class="fixed inset-0 bg-black/30"
-         @click="hide()"
-         x-transition:enter="transition ease-out duration-300"
-         x-transition:enter-start="opacity-0"
-         x-transition:enter-end="opacity-100"
-         x-transition:leave="transition ease-in duration-200"
-         x-transition:leave-start="opacity-100"
-         x-transition:leave-end="opacity-0">
-    </div>
-
-    <!-- Dialog -->
-    <div x-show="isOpen"
-         class="fixed inset-0 z-10 overflow-y-auto"
-         @click.away="hide()">
-        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-            <div x-show="isOpen"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                 x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
-                 x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                 class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
-
-                <div class="sm:flex sm:items-start">
-                    <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-                        <div class="mt-2">
-                            <p x-text="message" :class="{
-                                'text-red-500': type === 'error',
-                                'text-green-500': type === 'success'
-                            }" class="text-sm"></p>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-                    <button type="button"
-                            class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
-                            @click="hide()">
-                        Close
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 
 <script>
     document.addEventListener('livewire:initialized', function () {
@@ -95,13 +30,13 @@ class="relative z-50">
     <!-- Changes Remaining Card -->
     <div class="px-4 py-6 bg-nfl-background border rounded-lg shadow flex items-center justify-between">
         <h3 class="text-lg font-medium">Changes Remaining</h3>
-        <p class="mt-2 text-2xl font-bold">{{ $changesRemaining }} / 2</p>
+        <p class="mt-2 text-2xl font-bold">{{ $entry->getChangesRemaining() }} / 2</p>
     </div>
 
     <!-- Players Active Card -->
     <div class="px-4 py-6 bg-nfl-background border rounded-lg shadow flex items-center justify-between">
         <h3 class="text-lg font-medium">Players Active</h3>
-        <p class="mt-2 text-2xl font-bold">{{ $playersActive }} / 8</p>
+        <p class="mt-2 text-2xl font-bold">{{ $playersActive->count() }} / 8</p>
     </div>
 </div>
 
@@ -171,20 +106,23 @@ class="relative z-50">
                 </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
-            @foreach($entry->current_players->sortBy(function($player) {
-    $positionOrder = [
-        'QB' => 1,
-        'WR1' => 2,
-        'WR2' => 3,
-        'WR3' => 4,
-        'RB1' => 5,
-        'RB2' => 6,
-        'TE' => 7,
-        'FLEX' => 8
-    ];
-    return $positionOrder[$player->pivot->roster_position] ?? 999;
-})->sortBy('pivot.removed_at') as $player)
-                    <tr class="text-center {{!is_null($player->pivot->removed_at)?' bg-red-200':''}}" x-data="{ showDropdown: false, loading: false }">
+            @foreach($entry->players->sortBy(function($player) {
+                $positionOrder = [
+                    'QB' => 1,
+                    'WR1' => 2,
+                    'WR2' => 3,
+                    'WR3' => 4,
+                    'RB1' => 5,
+                    'RB2' => 6,
+                    'TE' => 7,
+                    'FLEX' => 8
+                ];
+                return $positionOrder[$player->pivot->roster_position] ?? 999;
+            })->sortBy(function($player) {
+                return is_null($player->pivot->removed_at) ?0 :1;
+            }) as $player)
+
+                    <tr class="text-center {{!is_null($player->pivot->removed_at)?' bg-red-200':(!$playersActive->contains($player->id)?'bg-gray-200':'')}}" x-data="{ showDropdown: false, loading: false }">
                         <td class="px-6 py-4 whitespace-nowrap capitalize">{{ $player->pivot->roster_position }}</td>
                         <td class="px-6 py-4 whitespace-nowrap">
                             {{ $player->name }} ({{ $player->team->name }})
@@ -196,6 +134,12 @@ class="relative z-50">
                         <td class="px-6 py-4 whitespace-nowrap">{{ is_null($player->pivot->removed_at) ? number_format($player->pivot->total_points, 1):''  }}</td>
                         <td class="px-6 py-4 whitespace-nowrap text-center relative">
                             @if(is_null($player->pivot->removed_at)&&!in_array($player->id, $lockedPlayers->pluck('id')->toArray()))
+                                @if($changesRemaining<=0)
+                                    <button type="button" disabled
+                                            class="px-3 py-1 cursor-not-allowed text-sm text-white bg-blue-300 rounded">
+                                        Change Player
+                                    </button>
+                                @else
                                 <div>
                                     <livewire:player-selector
                                         :entry="$entry"
@@ -203,8 +147,18 @@ class="relative z-50">
                                         :rosterPosition="$player->pivot->roster_position"
                                         :key="'player-'.$player->id" />
                                 </div>
-                            @else
+                                @endif
+                            @elseif(is_null($player->pivot->removed_at))
                                 <span class="text-red-500">Locked</span>
+                            @else
+                                @if($revertChangeData->contains('cID',$player->id))
+                                    <button type="button" disabled
+                                            class="px-3 py-1 cursor-pointer text-sm text-white bg-red-600 rounded">
+                                        Undo Changed
+                                    </button>
+                                @else
+                                    <span class="text-red-500"></span>
+                                @endif
                             @endif
                         </td>
                     </tr>

--- a/resources/views/entries/roster.blade.php
+++ b/resources/views/entries/roster.blade.php
@@ -126,6 +126,9 @@
                         <td class="px-6 py-4 whitespace-nowrap capitalize">{{ $player->pivot->roster_position }}</td>
                         <td class="px-6 py-4 whitespace-nowrap">
                             {{ $player->name }} ({{ $player->team->name }})
+                            @if(!is_null($player->pivot->removed_at))
+                                <span class="block text-xs">Added: {{$transactions->firstWhere('dropped_player_id',$player->id)->addedPlayer->name}} ({{$transactions->firstWhere('dropped_player_id',$player->id)->created_at->format('m/d/Y g:i a')}})</span>
+                            @endif
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">{{ $entry->getPlayerPoints($player->id,'Wild Card') }}</td>
                         <td class="px-6 py-4 whitespace-nowrap">{{ is_null($player->pivot->removed_at) ? $entry->getPlayerPoints($player->id,'Divisional'):'' }}</td>

--- a/resources/views/entries/roster.blade.php
+++ b/resources/views/entries/roster.blade.php
@@ -151,15 +151,20 @@
                             @elseif(is_null($player->pivot->removed_at))
                                 <span class="text-red-500">Locked</span>
                             @else
-                                @if($revertChangeData->contains('cID',$player->id))
-                                    <button type="button" disabled
+                                @if($transactions->firstWhere('dropped_player_id',$player->id)->revoke===true)
+                                <form method="POST" action="{{ route('entries.revert-player', $entry) }}">
+                                    <input type="hidden" id="transaction_id" name="transaction_id" value="{{$transactions->firstWhere('dropped_player_id',$player->id)->id}}" />
+                                    @csrf
+
+                                    <button type="submit"
                                             class="px-3 py-1 cursor-pointer text-sm text-white bg-red-600 rounded">
-                                        Undo Changed
+                                        Cancel Change
                                     </button>
-                                @else
-                                    <span class="text-red-500"></span>
-                                @endif
+                                </form>
+                                    @endif
+
                             @endif
+
                         </td>
                     </tr>
                 @endforeach

--- a/resources/views/livewire/player-selector.blade.php
+++ b/resources/views/livewire/player-selector.blade.php
@@ -1,5 +1,5 @@
-<div 
-    x-data="{ 
+<div
+    x-data="{
         showDropdown: false,
         showDialog: false,
         dialogType: '',
@@ -14,18 +14,18 @@
     }"
     class="relative"
 >
-    <button 
+    <button
         @click="showDropdown = !showDropdown"
         class="px-3 py-1 text-sm text-white bg-blue-500 rounded hover:bg-blue-600">
         Change Player
     </button>
-    
+
     <!-- Dialog Modal -->
-    <div x-show="showDialog" 
+    <div x-show="showDialog"
          x-cloak
-         class="fixed inset-0 z-50 overflow-y-auto" 
-         aria-labelledby="modal-title" 
-         role="dialog" 
+         class="fixed inset-0 z-50 overflow-y-auto"
+         aria-labelledby="modal-title"
+         role="dialog"
          aria-modal="true"
          style="display: flex; items: center; justify-content: center;">
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
@@ -69,15 +69,16 @@
     </div>
 
     <!-- Player Selection Dropdown -->
-    <div 
-    x-show="showDropdown" 
+    <div
+        x-cloak
+    x-show="showDropdown"
     @click.away="showDropdown = false"
     class="absolute right-0 mt-2 w-64 bg-white rounded-md shadow-lg z-[60] border"
     style="transform: translateX(-50%);">
         <div class="p-4">
             <form wire:submit="changePlayer">
-                <select 
-                    wire:model="selectedPlayerId" 
+                <select
+                    wire:model="selectedPlayerId"
                     class="w-full rounded-md border-gray-300 text-sm mb-4"
                     required
                 >
@@ -88,15 +89,15 @@
                         </option>
                     @endforeach
                 </select>
-                
+
                 <div class="flex justify-end space-x-2">
-                    <button 
+                    <button
                         type="button"
                         @click="showDropdown = false"
                         class="px-3 py-1 text-sm text-gray-600 bg-gray-100 rounded hover:bg-gray-200">
                         Cancel
                     </button>
-                    <button 
+                    <button
                         type="submit"
                         class="px-3 py-1 text-sm text-white bg-blue-500 rounded hover:bg-blue-600">
                         Confirm Change

--- a/resources/views/livewire/position-swapper.blade.php
+++ b/resources/views/livewire/position-swapper.blade.php
@@ -1,0 +1,17 @@
+<div class="flex items-center space-x-2">
+    @if($rosterPosition === 'FLEX' || in_array($entry->players()->find($currentPlayerId)->position, ['RB', 'WR', 'TE']))
+        <select wire:model="swapWithId" class="rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+            <option value="">Select player to swap</option>
+            @foreach($eligiblePlayers as $player)
+                <option value="{{ $player->id }}">
+                    {{ $player->name }} ({{ $player->pivot->roster_position }})
+                </option>
+            @endforeach
+        </select>
+        <button wire:click="swapPosition" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            Swap
+        </button>
+    @else
+        <span class="text-gray-500">Not eligible for FLEX swap</span>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,12 +59,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/entries', [EntryController::class, 'store'])->name('entries.store');
     Route::get('/entries/{entry}/roster', [EntryController::class, 'roster'])->name('entries.roster');
     Route::post('/entries/{entry}/add-player', [EntryController::class, 'addPlayer'])->name('entries.add-player');
+    Route::post('/entries/{entry}/revert-player', [EntryController::class, 'revertPlayer'])->name('entries.revert-player');
     Route::post('/entries/{entry}/transactions', [EntryController::class, 'processTransaction'])->name('entries.process-transaction');
 
     // Standings routes
     Route::get('/standings', [StandingsController::class, 'index'])->name('standings.index');
     Route::get('/standings/week/{week}', [StandingsController::class, 'weekly'])->name('standings.weekly');
-    
+
     // Public entry routes
     Route::get('/public-entries', [EntryController::class, 'publicIndex'])->name('entries.public');
     Route::get('/public-entries/{entry}', [EntryController::class, 'publicRoster'])->name('entries.public.roster');
@@ -81,13 +82,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
 Route::middleware(['auth', 'admin'])->prefix('admin')->group(function () {
     Route::get('/', [AdminController::class, 'index'])->name('admin.dashboard');
-    
+
     // Player Management
     Route::resource('players', PlayerController::class, ['as' => 'admin']);
-    
+
     // Game Management
     Route::resource('games', GameController::class, ['as' => 'admin']);
-    
+
     // Team Management
     Route::resource('teams', TeamController::class, ['as' => 'admin']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/entries/{entry}/add-player', [EntryController::class, 'addPlayer'])->name('entries.add-player');
     Route::post('/entries/{entry}/revert-player', [EntryController::class, 'revertPlayer'])->name('entries.revert-player');
     Route::post('/entries/{entry}/transactions', [EntryController::class, 'processTransaction'])->name('entries.process-transaction');
+    Route::post('/entries/{entry}/swap-flex', [EntryController::class, 'swapWithFlex'])->name('entries.swap-flex');
 
     // Standings routes
     Route::get('/standings', [StandingsController::class, 'index'])->name('standings.index');


### PR DESCRIPTION
NEED: php artisan migrate  ...... to add deleted_at to transactions table.  Will use this to store log of cancelled changes

Max changes now determined by Entry->getChangesRemaining(). It takes 10- entry_players count this if 2 changes they will have 10 records resulting in 0 changes remaining.

//roster.blade.php
-Grays players that are out
-Disables change button if max changes reached
-Added revert button for changed players if they havent started their next game yet. **Need to test more -shows correct points, changes remaining, players active in summary

NOTE: This may break some things elsewhere I only worked on the roster page.  I didn't change any existing model relations so I don't expect any issues. There are some complex queries but no updates so hopefully we dont run into more sqlite problems like we had with removed_at update.